### PR TITLE
fix: Use sd-server img2img endpoint for proper mask-based inpainting

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,11 +398,6 @@
 <div class="toolbar toolbar-row2">
   <label for="prompt-input">Prompt</label>
   <input type="text" id="prompt-input" value="seamless background fill" placeholder="Describe the fill...">
-  <div class="toolbar-sep"></div>
-  <label for="strength-slider">Strength <span id="strength-value">0.75</span></label>
-  <input type="range" id="strength-slider" min="0" max="1" step="0.05" value="0.75">
-  <label for="steps-slider">Steps <span id="steps-value">4</span></label>
-  <input type="range" id="steps-slider" min="1" max="20" step="1" value="4">
 </div>
 
 <!-- Content -->


### PR DESCRIPTION
Lemonade server's /api/v1/images/edits routes through sd-server's EDIT mode which places images into ref_images and ignores masks entirely. Call sd-server's /sdapi/v1/img2img endpoint directly (discovered via the health API) which properly sets init_image and supports denoising_strength + mask-based inpainting.

Also removes the Strength and Steps UI sliders since those parameters are no longer controllable through the lemonade server API.